### PR TITLE
크롤러 v2

### DIFF
--- a/github-profile-crawler/getCSV.spec.ts
+++ b/github-profile-crawler/getCSV.spec.ts
@@ -1,15 +1,18 @@
 import fs from 'fs';
-import 'dotenv/config';
 
 import { UsersDataWithRepos } from './types';
 import processData from './utils/processData';
 import { saveToCSV } from './utils/saveToCSV';
+import { DATA_SIZE, ID_PRESET } from './getEnv';
 
 async function main() {
   console.log('🚀 CSV파일을 생성해요!');
 
   const userList: UsersDataWithRepos[] = JSON.parse(
-    fs.readFileSync('results/userDataWithRepos.json', 'utf8')
+    fs.readFileSync(
+      `results/userDataWithRepos_v2_${ID_PRESET}_${ID_PRESET + DATA_SIZE}.json`,
+      'utf8'
+    )
   );
 
   if (userList === undefined || userList.length === 0) {
@@ -21,7 +24,7 @@ async function main() {
 
   saveToCSV({
     profiles: processedData,
-    startIndex: Number(process.env.ID_PRESET || '58812280'),
+    startIndex: ID_PRESET,
     endIndex: userList[userList.length - 1].id,
   });
 }

--- a/github-profile-crawler/getEnv.ts
+++ b/github-profile-crawler/getEnv.ts
@@ -1,0 +1,6 @@
+import 'dotenv/config';
+
+const ID_PRESET = parseInt(process.env.ID_PRESET || '58812280');
+const DATA_SIZE = parseInt(process.env.DATA_SIZE || '100');
+
+export { ID_PRESET, DATA_SIZE };

--- a/github-profile-crawler/getRepos.spec.ts
+++ b/github-profile-crawler/getRepos.spec.ts
@@ -1,15 +1,18 @@
 import fs from 'fs';
-import 'dotenv/config';
 
-import { GitHubRepository, GitHubUser, UsersDataWithRepos } from './types';
+import { GitHubUser, isLanguage, UsersDataWithRepos } from './types';
 import stopWatch from './utils/stopWatch';
 import { getGitHubReposList } from './utils/getGitHubReposList';
+import { DATA_SIZE, ID_PRESET } from './getEnv';
 
 async function main() {
   console.log('🚀 유저 별 레포지토리 목록을 추가해요!');
 
   const userList: GitHubUser[] = JSON.parse(
-    fs.readFileSync('results/users.json', 'utf8')
+    fs.readFileSync(
+      `results/users_v2_${ID_PRESET}_${ID_PRESET + DATA_SIZE}.json`,
+      'utf8'
+    )
   );
 
   if (userList === undefined || userList.length === 0) {
@@ -31,26 +34,25 @@ async function main() {
     );
 
     const repos = await getGitHubReposList(user.repos_url);
-    const filteredRepos = repos.filter(repo => repo.size > 500);
-    if (filteredRepos.length < 3) continue;
-    const starredRepos = await getGitHubReposList(
-      user.starred_url.split('{')[0]
+    const filteredRepos = repos.filter(
+      repo =>
+        repo.size > 500 && repo.language !== null && isLanguage(repo.language)
     );
-    const filteredStarredRepos = starredRepos.filter(repo => repo.size > 500);
+    if (filteredRepos.length < 3) continue;
     usersDataWithRepos.push({
       ...user,
-      repos: filteredRepos.slice(0, 10),
-      starredRepos: filteredStarredRepos.slice(0, 10),
+      repos: filteredRepos,
     });
   }
 
   console.log(
     `${userList.length}개의 유저 데이터 중 유효한 ${usersDataWithRepos.length}개의 프로필을 크롤링했어요!`
   );
+  console.log(`종합 수율: ${(usersDataWithRepos.length / DATA_SIZE) * 100}%`);
   stop();
 
   fs.writeFileSync(
-    'results/userDataWithRepos.json',
+    `results/userDataWithRepos_v2_${ID_PRESET}_${ID_PRESET + DATA_SIZE}.json`,
     JSON.stringify(usersDataWithRepos, null, 2)
   );
 }

--- a/github-profile-crawler/getUsers.spec.ts
+++ b/github-profile-crawler/getUsers.spec.ts
@@ -1,21 +1,20 @@
 import fs from 'fs';
-import 'dotenv/config';
 
 import { getGitHubUserList } from './utils/getGitHubUserList';
-
-const ID_PRESET = parseInt(process.env.ID_PRESET || '58812280');
+import { ID_PRESET, DATA_SIZE } from './getEnv';
 
 async function main() {
   console.log('🚀 유저 리스트를 가져와요!');
 
-  const dataSize = parseInt(process.env.DATA_SIZE || '100');
-
-  const profileData = await getGitHubUserList(ID_PRESET, dataSize);
+  const profileData = await getGitHubUserList(ID_PRESET, DATA_SIZE);
 
   console.log(`${profileData.length}개의 유저 데이터를 가져왔어요!`);
 
   // results/users.json 파일로 저장
-  fs.writeFileSync('results/users.json', JSON.stringify(profileData, null, 2));
+  fs.writeFileSync(
+    `results/users_v2_${ID_PRESET}_${ID_PRESET + DATA_SIZE}.json`,
+    JSON.stringify(profileData, null, 2)
+  );
 }
 
 main().catch(console.error);

--- a/github-profile-crawler/mergeData.spec.ts
+++ b/github-profile-crawler/mergeData.spec.ts
@@ -5,13 +5,13 @@ async function main() {
   console.log('🚀 CSV 파일들을 합치는 중이에요!');
 
   const resultsDir = 'results';
-  const outputFile = path.join(resultsDir, 'github_profiles.csv');
+  const outputFile = path.join(resultsDir, 'github_profiles_total_v2.csv');
 
   // results 디렉토리에서 github_profiles로 시작하는 CSV 파일들을 찾습니다
   const files = fs
     .readdirSync(resultsDir)
     .filter(
-      file => file.startsWith('github_profiles') && file.endsWith('.csv')
+      file => file.startsWith('github_profiles_v2') && file.endsWith('.csv')
     );
 
   if (files.length === 0) {

--- a/github-profile-crawler/types.ts
+++ b/github-profile-crawler/types.ts
@@ -27,6 +27,8 @@ export type LanguageCount = {
 
 export interface CSVInterface extends LanguageCount {
   username: string;
+  userID: number;
+  repoCount: number;
 }
 
 export interface GitHubUser {
@@ -106,7 +108,6 @@ export interface GitHubRepository {
 
 export type UsersDataWithRepos = GitHubUser & {
   repos: GitHubRepository[];
-  starredRepos: GitHubRepository[];
 };
 
 export const isLanguage = (language: string): language is Language => {

--- a/github-profile-crawler/utils/getGitHubUserList.ts
+++ b/github-profile-crawler/utils/getGitHubUserList.ts
@@ -26,12 +26,14 @@ export const getGitHubUserList = async (preset: number, dataSize: number) => {
     lastIndex = data[data.length - 1].id;
     profileData.push(...data);
   }
-  const data = await fetchData(lastIndex, dataSize % 100);
-  if (typeof data === 'object' && 'message' in data) {
-    console.log('API 호출 오류 발생: ' + data.message);
-    return [];
+  if (dataSize % 100 !== 0) {
+    const data = await fetchData(lastIndex, dataSize % 100);
+    if (typeof data === 'object' && 'message' in data) {
+      console.log('API 호출 오류 발생: ' + data.message);
+      return [];
+    }
+    profileData.push(...data);
   }
-  profileData.push(...data);
 
   const filteredData = profileData.filter(
     (user: GitHubUser) =>

--- a/github-profile-crawler/utils/getGitHubUserList.ts
+++ b/github-profile-crawler/utils/getGitHubUserList.ts
@@ -26,6 +26,12 @@ export const getGitHubUserList = async (preset: number, dataSize: number) => {
     lastIndex = data[data.length - 1].id;
     profileData.push(...data);
   }
+  const data = await fetchData(lastIndex, dataSize % 100);
+  if (typeof data === 'object' && 'message' in data) {
+    console.log('API 호출 오류 발생: ' + data.message);
+    return [];
+  }
+  profileData.push(...data);
 
   const filteredData = profileData.filter(
     (user: GitHubUser) =>

--- a/github-profile-crawler/utils/processData.ts
+++ b/github-profile-crawler/utils/processData.ts
@@ -32,11 +32,6 @@ const processData = async (
     };
     for (const repo of user.repos) {
       if (repo.language && isLanguage(repo.language)) {
-        languageCount[repo.language] += 10;
-      }
-    }
-    for (const repo of user.starredRepos) {
-      if (repo.language && isLanguage(repo.language)) {
         languageCount[repo.language] += 1;
       }
     }
@@ -58,6 +53,8 @@ const processData = async (
     ret.push({
       ...languageCount,
       username: user.login,
+      userID: user.id,
+      repoCount: user.repos.length,
     });
   }
 

--- a/github-profile-crawler/utils/saveToCSV.ts
+++ b/github-profile-crawler/utils/saveToCSV.ts
@@ -13,12 +13,14 @@ export const saveToCSV = async ({
   endIndex,
 }: SaveToCSVProps) => {
   // 헤더 열 정의
-  let csvContent = `유저 ID, ${languages.join(', ')}\n`;
+  let csvContent = `user_ID, username, repo_count, ${languages.join(', ')}\n`;
 
   // 프로필 추가
   for (const profile of profiles) {
     const row = [
+      profile.userID,
       profile.username,
+      profile.repoCount,
       ...languages.map(language => profile[language]),
     ].join(',');
     csvContent += `${row}\n`;
@@ -26,7 +28,7 @@ export const saveToCSV = async ({
 
   // root 디렉토리에 저장하기
   const filePath = path.join(
-    `./results/github_profiles_${startIndex}-${endIndex}.csv`
+    `./results/github_profiles_v2_${startIndex}-${endIndex}.csv`
   );
 
   fs.writeFileSync(filePath, csvContent);


### PR DESCRIPTION
- 중간 단계 json 파일을 누적 저장합니다
  - 크롤러 로직을 변경하더라도 처음부터 api 호출 안하고 중간 json 데이터를 사용하면 콜 아낄 수 있음
- Star 표시한 레포지토리 긁어오기 삭제
- 레포지토리 수 제한을 없애서 그 사람이 가지고 있는 모든 유효한 레포지토리로 통계냄,
유효 레포지토리 판단 기준에 17가지 언어에 부합하는지도 포함
- CSV에 user_id와 repo_count(통계 내는데 사용한 레포 개수) 칼럼을 추가합니다